### PR TITLE
fix(boilerplate): remove v1 reference

### DIFF
--- a/plugins/fabrique/boilerplates/workspace-webhook/.kontinuous/config.yaml
+++ b/plugins/fabrique/boilerplates/workspace-webhook/.kontinuous/config.yaml
@@ -2,4 +2,4 @@ projectName: myProjectName
 
 dependencies:
   fabrique:
-    import: SocialGouv/kontinuous/plugins/fabrique@v1
+    import: SocialGouv/kontinuous/plugins/fabrique


### PR DESCRIPTION
the current version raise 

```sh
➜ npx kontinuous build          
[Error: ENOENT: no such file or directory, lstat '/Users/xxx/kontinuous/plugins/fabrique#v1'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/Users/xxx/kontinuous/plugins/fabrique#v1'
}
```