### PR TITLE
feat: embed-secrets patch

### DIFF
--- a/packages/common/utils/kubeseal.js
+++ b/packages/common/utils/kubeseal.js
@@ -1,0 +1,1 @@
+module.exports = async () => {}

--- a/packages/common/utils/need-kubeseal.js
+++ b/packages/common/utils/need-kubeseal.js
@@ -1,0 +1,61 @@
+const os = require("os")
+
+const fs = require("fs-extra")
+const decompress = require("decompress")
+
+const versions = require("../versions")
+
+const needBin = require("./need-bin")
+const downloadFile = require("./download-file")
+
+const kubesealVersion = process.env.KUBESEAL_VERSION || versions.kubeseal
+
+const download = async (options) => {
+  const { logger } = options
+
+  let arch = os.arch()
+  let ext = ""
+  switch (arch) {
+    case "x64":
+      arch = "amd64"
+      break
+    default:
+  }
+  let platform = os.platform()
+  switch (platform) {
+    case "darwin":
+      break
+    case "win32":
+      ext = ".exe"
+      throw new Error(
+        "kubeseal doesn't have a cli package for windows actually, see https://github.com/bitnami-labs/sealed-secrets/issues/105"
+      )
+    case "linux":
+      break
+    default:
+      platform = "linux"
+  }
+
+  const fileName = `kubeseal-${kubesealVersion}-${platform}-${arch}.tar.gz`
+
+  const { cacheDir } = options
+
+  const cachePath = `${cacheDir}/bin`
+  await fs.ensureDir(cachePath)
+  const zfile = `${cachePath}/${fileName}`
+
+  if (!(await fs.pathExists(zfile))) {
+    const downloadUrl = `https://github.com/bitnami-labs/sealed-secrets/releases/download/v${kubesealVersion}/${fileName}`
+    logger.info(`⬇️  downloading ${downloadUrl}`)
+    await downloadFile(downloadUrl, zfile, logger)
+  }
+  const { addPath } = options
+  await decompress(zfile, cachePath)
+  const unzippedDir = `${cachePath}/${platform}-${arch}`
+  const unzippedHelm = `${unzippedDir}/kubeseal${ext}`
+  await fs.move(unzippedHelm, `${addPath}/kubeseal`)
+  await fs.remove(unzippedDir)
+}
+
+module.exports = (options = {}) =>
+  needBin("kubectl", download, { ...options, version: kubesealVersion })

--- a/packages/common/versions.js
+++ b/packages/common/versions.js
@@ -11,6 +11,9 @@ module.exports = {
   // renovate: datasource=github-releases depName=stern/stern
   stern: "1.22.0",
 
+  // renovate: datasource=github-releases depName=bitnami-labs/sealed-secrets extractVersion=^sealed-secrets-(?<version>.+)$
+  kubeseal: "0.19.4",
+
   // renovate: datasource=github-releases depName=carvel-dev/kapp
   kapp: "0.54.2",
 }

--- a/plugins/contrib/kontinuous.yaml
+++ b/plugins/contrib/kontinuous.yaml
@@ -17,6 +17,8 @@ patches:
     enabled: false
   needsUsingKapp:
     enabled: false
+  embedSecrets:
+    enabled: false
   filterDisableKapp:
     enabled: true
   helm:

--- a/plugins/contrib/lib/import-secrets.js
+++ b/plugins/contrib/lib/import-secrets.js
@@ -1,0 +1,149 @@
+const async = require("async")
+
+module.exports = async ({ manifests, options, context, callback }) => {
+  const { utils, config, logger, kubectl } = context
+  const { KontinuousPluginError } = utils
+
+  const { kubeconfig, kubeconfigContext, ciNamespace, environment } = config
+
+  const { surviveOnBrokenCluster = false, applyConcurrencyLimit = 1 } = options
+
+  const allNamespaces = manifests
+    .filter((manifest) => manifest.kind === "Namespace")
+    .map((manifest) => manifest.metadata.name)
+
+  const kubectlOptions = {
+    kubeconfig,
+    kubeconfigContext,
+    surviveOnBrokenCluster,
+  }
+
+  const { secrets } = options
+
+  const importSecretExec = async (secret) => {
+    const {
+      key,
+      enabled = true,
+      toAllNamespace = true,
+      reload = false,
+      required = false,
+    } = secret
+    if (!enabled) {
+      return
+    }
+    let { fromNamespace, toNamespace, to, from, env } = secret
+
+    if (env) {
+      if (!Array.isArray(env)) {
+        env = [env]
+      }
+      if (!env.includes(environment)) {
+        return
+      }
+    }
+
+    if (!to) {
+      to = key
+    }
+    if (!from) {
+      from = key
+    }
+    if (!Array.isArray(from)) {
+      from = [from]
+    }
+
+    if (!fromNamespace) {
+      fromNamespace = ciNamespace
+    }
+
+    if (toAllNamespace) {
+      toNamespace = allNamespaces.filter((ns) => {
+        if (from === to) {
+          return ns !== fromNamespace
+        }
+        return true
+      })
+    }
+
+    if (!Array.isArray(toNamespace)) {
+      toNamespace = [toNamespace]
+    }
+
+    let needed
+    if (reload) {
+      needed = true
+    } else {
+      needed = false
+      await Promise.all(
+        toNamespace.map(async (namespace) => {
+          try {
+            await kubectl(`get -n ${namespace} secret ${to} -ojson`, {
+              ...kubectlOptions,
+              logInfo: false,
+              logError: false,
+            })
+          } catch (_err) {
+            needed = true
+          }
+        })
+      )
+    }
+
+    if (!needed) {
+      logger.debug(`✔️  secrets already present "${to}"`)
+      return
+    }
+
+    let secretJSON
+    for (const fromSecretName of from) {
+      try {
+        secretJSON = await kubectl(
+          `get -n ${fromNamespace} secret ${fromSecretName} -ojson`,
+          { ...kubectlOptions, logInfo: false, logError: false }
+        )
+        if (secretJSON) {
+          break
+        }
+      } catch (_err) {
+        // do nothing
+      }
+    }
+
+    if (!secretJSON) {
+      if (required) {
+        throw new KontinuousPluginError(
+          `missing required secret "${to}" looking for "${from.join(
+            '","'
+          )}" in namespace "${fromNamespace}"`
+        )
+      }
+      return
+    }
+
+    const kubeSecret = JSON.parse(secretJSON)
+
+    const { metadata } = kubeSecret
+    delete metadata.namespace
+    delete metadata.resourceVersion
+    delete metadata.uid
+    delete metadata.creationTimestamp
+    delete metadata.ownerReferences
+    metadata.name = to
+
+    await Promise.all(
+      toNamespace.map(async (namespace) =>
+        callback({ secret: kubeSecret, namespace, kubectlOptions })
+      )
+    )
+  }
+
+  const q = async.queue(importSecretExec, applyConcurrencyLimit)
+
+  const importSecret = async (secret) => q.pushAsync(secret)
+
+  await Promise.all(
+    Object.entries(secrets).map(([key, secret]) =>
+      importSecret({ key, ...(secret || {}) })
+    )
+  )
+}

--- a/plugins/contrib/patches/05.2-embed-secrets.js
+++ b/plugins/contrib/patches/05.2-embed-secrets.js
@@ -1,0 +1,39 @@
+const importSecret = require("../lib/import-secrets")
+
+module.exports = async (manifests, options, context) => {
+  const { config, logger, kubectl, utils, needBin } = context
+  const { KontinuousPluginError, needKubeseal } = utils
+
+  await needBin(needKubeseal)
+
+  let { kubesealEndpoint } = options
+
+  if (!kubesealEndpoint) {
+    const { clusters } = options
+    const cluster = config.environment === "prod" ? clusters.prod : clusters.dev
+    if (cluster) {
+      ;({ kubesealEndpoint } = cluster)
+    }
+  }
+  if (!kubesealEndpoint) {
+    throw new KontinuousPluginError(
+      `missing "kubesealEndpoint" required option`
+    )
+  }
+
+  await importSecret({
+    manifests,
+    options,
+    context,
+    callback: async ({ secret, namespace, kubectlOptions }) => {
+      try {
+        await kubectl(`apply -n ${namespace} -f -`, {
+          ...kubectlOptions,
+          stdin: JSON.stringify(secret),
+        })
+      } catch (error) {
+        logger.error({ error }, "unable to copy kubeconfig secret")
+      }
+    },
+  })
+}

--- a/plugins/contrib/pre-deploy/02-import-secrets.js
+++ b/plugins/contrib/pre-deploy/02-import-secrets.js
@@ -1,156 +1,21 @@
-const async = require("async")
+const importSecret = require("../lib/import-secrets")
 
 module.exports = async (manifests, options, context) => {
-  const { utils, config, logger, kubectl } = context
-  const { KontinuousPluginError } = utils
+  const { logger, kubectl } = context
 
-  const { kubeconfig, kubeconfigContext, ciNamespace, environment } = config
-
-  const { surviveOnBrokenCluster = false, applyConcurrencyLimit = 1 } = options
-
-  const allNamespaces = manifests
-    .filter((manifest) => manifest.kind === "Namespace")
-    .map((manifest) => manifest.metadata.name)
-
-  const kubectlOptions = {
-    kubeconfig,
-    kubeconfigContext,
-    surviveOnBrokenCluster,
-  }
-
-  const { secrets } = options
-
-  const importSecretExec = async (secret) => {
-    const {
-      key,
-      enabled = true,
-      toAllNamespace = true,
-      reload = false,
-      required = false,
-    } = secret
-    if (!enabled) {
-      return
-    }
-    let { fromNamespace, toNamespace, to, from, env } = secret
-
-    if (env) {
-      if (!Array.isArray(env)) {
-        env = [env]
-      }
-      if (!env.includes(environment)) {
-        return
-      }
-    }
-
-    if (!to) {
-      to = key
-    }
-    if (!from) {
-      from = key
-    }
-    if (!Array.isArray(from)) {
-      from = [from]
-    }
-
-    if (!fromNamespace) {
-      fromNamespace = ciNamespace
-    }
-
-    if (toAllNamespace) {
-      toNamespace = allNamespaces.filter((ns) => {
-        if (from === to) {
-          return ns !== fromNamespace
-        }
-        return true
-      })
-    }
-
-    if (!Array.isArray(toNamespace)) {
-      toNamespace = [toNamespace]
-    }
-
-    let needed
-    if (reload) {
-      needed = true
-    } else {
-      needed = false
-      await Promise.all(
-        toNamespace.map(async (namespace) => {
-          try {
-            await kubectl(`get -n ${namespace} secret ${to} -ojson`, {
-              ...kubectlOptions,
-              logInfo: false,
-              logError: false,
-            })
-          } catch (_err) {
-            needed = true
-          }
-        })
-      )
-    }
-
-    if (!needed) {
-      logger.debug(`✔️  secrets already present "${to}"`)
-      return
-    }
-
-    let kubeconfigSecretJSON
-    for (const fromSecretName of from) {
+  await importSecret({
+    manifests,
+    options,
+    context,
+    callback: async ({ secret, namespace, kubectlOptions }) => {
       try {
-        kubeconfigSecretJSON = await kubectl(
-          `get -n ${fromNamespace} secret ${fromSecretName} -ojson`,
-          { ...kubectlOptions, logInfo: false, logError: false }
-        )
-        if (kubeconfigSecretJSON) {
-          break
-        }
-      } catch (_err) {
-        // do nothing
+        await kubectl(`apply -n ${namespace} -f -`, {
+          ...kubectlOptions,
+          stdin: JSON.stringify(secret),
+        })
+      } catch (error) {
+        logger.error({ error }, "unable to copy secret")
       }
-    }
-
-    if (!kubeconfigSecretJSON) {
-      if (required) {
-        throw new KontinuousPluginError(
-          `missing required secret "${to}" looking for "${from.join(
-            '","'
-          )}" in namespace "${fromNamespace}"`
-        )
-      }
-      return
-    }
-
-    const kubeconfigSecret = JSON.parse(kubeconfigSecretJSON)
-
-    const { metadata } = kubeconfigSecret
-    delete metadata.namespace
-    delete metadata.resourceVersion
-    delete metadata.uid
-    delete metadata.creationTimestamp
-    delete metadata.ownerReferences
-    metadata.name = to
-
-    await Promise.all(
-      toNamespace.map(async (namespace) => {
-        try {
-          await kubectl(`apply -n ${namespace} -f -`, {
-            ...kubectlOptions,
-            stdin: JSON.stringify(kubeconfigSecret),
-          })
-        } catch (error) {
-          logger.error({ error }, "unable to copy kubeconfig secret")
-        }
-      })
-    )
-  }
-
-  const q = async.queue(importSecretExec, applyConcurrencyLimit)
-
-  const importSecret = async (secret) => q.pushAsync(secret)
-
-  await Promise.all(
-    Object.entries(secrets).map(([key, secret]) =>
-      importSecret({ key, ...(secret || {}) })
-    )
-  )
+    },
+  })
 }

--- a/plugins/fabrique/extends/deploy-with-kubectl.yaml
+++ b/plugins/fabrique/extends/deploy-with-kubectl.yaml
@@ -3,22 +3,9 @@ config:
   
 dependencies:
   contrib:
-    preDeploy:
-      cleanFailed:
-        enabled: false
-    deploySidecars:
-      failfast:
-        enabled: false
-      stern:
-        enabled: true
-      progressing:
-        enabled: true
     patches:
       needsUsingInitcontainers:
         enabled: true
-      needsUsingKapp:
-        enabled: false
-      filterDisableKapp:
+      embedSecrets:
         enabled: true
-      reloader:
-        enabled: true
+      


### PR DESCRIPTION
Embed secrets as sealed to make independent manifests (combined with needs as init-containers)
so we can deploy with argo-cd or kubectl the produced manifests.

As asked by the team many times.

Left in standby because the team doesn't want new developments for now.