### PR TITLE
fix(certs): dont add cert-manager annotations for external domains

### DIFF
--- a/packages/kontinuous/tests/__snapshots__/redirect.prod.yaml
+++ b/packages/kontinuous/tests/__snapshots__/redirect.prod.yaml
@@ -220,9 +220,6 @@ metadata:
     kontinuous/chartPath: project.fabrique.contrib.app
     kontinuous/source: project/charts/fabrique/charts/contrib/charts/app/templates/ingress.yaml
     kontinuous/deployment: test-redirect-feature-branch-1-ffac537e6cbbf934b08745-5gn1hkye
-    cert-manager.io: cluster-issuer
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/tls-acme: \\"true\\"
   labels:
     component: app
     application: test-redirect

--- a/packages/kontinuous/tests/__snapshots__/values-js.dev.yaml
+++ b/packages/kontinuous/tests/__snapshots__/values-js.dev.yaml
@@ -221,9 +221,6 @@ metadata:
     kontinuous/chartPath: project.fabrique.contrib.app
     kontinuous/source: project/charts/fabrique/charts/contrib/charts/app/templates/ingress.yaml
     kontinuous/deployment: test-values-js-feature-branch-1-ffac537e6cbbf934b0874-6cv8lfvm
-    cert-manager.io: cluster-issuer
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/tls-acme: \\"true\\"
   labels:
     component: app
     application: test-values-js

--- a/plugins/contrib/patches/certs.js
+++ b/plugins/contrib/patches/certs.js
@@ -1,4 +1,5 @@
 const hasWildcard = (host) => host.endsWith(".dev.fabrique.social.gouv.fr")
+const isInternalHost = (host) => host.endsWith(".fabrique.social.gouv.fr")
 
 module.exports = (manifests, _options, { _config }) => {
   // const { environment } = config
@@ -18,7 +19,9 @@ module.exports = (manifests, _options, { _config }) => {
         }
         tlsEntry.secretName = "wildcard-crt"
       }
-      if (!hosts.every(hasWildcard)) {
+
+      // apply cert-manager annotations only for internal, non-wildcard hosts
+      if (!hosts.every(hasWildcard) && hosts.every(isInternalHost)) {
         if (!manifest.metadata) {
           manifest.metadata = {}
         }


### PR DESCRIPTION
dont add cert-manager annotations when tls domains are external