### PR TITLE
fix: enable clean orphan

### DIFF
--- a/.github/workflows/tests-deploy.yaml
+++ b/.github/workflows/tests-deploy.yaml
@@ -98,7 +98,7 @@ jobs:
             ${{ matrix.testParams.inlineValues || '' }}
           KS_WORKSPACE_PATH: ${{ matrix.testParams.cwd }}
           KS_INLINE_CONFIG_SET: |
-            dependencies.fabrique.dependencies.contrib.options.guessApiResources: true
+            dependencies.fabrique.dependencies.contrib.preDeploy.cleanOrphan.options.crdApiResources: []
         run: ./kontinuous deploy
       
       - name: run test script

--- a/.github/workflows/tests-deploy.yaml
+++ b/.github/workflows/tests-deploy.yaml
@@ -97,6 +97,8 @@ jobs:
           KS_INLINE_VALUES: |
             ${{ matrix.testParams.inlineValues || '' }}
           KS_WORKSPACE_PATH: ${{ matrix.testParams.cwd }}
+          KS_INLINE_CONFIG_SET: |
+            dependencies.fabrique.dependencies.contrib.options.guessApiResources: true
         run: ./kontinuous deploy
       
       - name: run test script

--- a/plugins/fabrique/kontinuous.yaml
+++ b/plugins/fabrique/kontinuous.yaml
@@ -75,7 +75,7 @@ dependencies:
       cleanFailed:
         enabled: true
       cleanOrphan:
-        enabled: false
+        enabled: true
         options:
           nativeApiResources:
             - configmaps


### PR DESCRIPTION
si on créé une ressource (ex HPA) et qu'on l'enlève, elle n'est pas supprimée sans l'activation de clean-orphan