### PR TITLE
fix(pg): add a subfolder for cnpg cluster cron backups

### DIFF
--- a/packages/kontinuous/tests/__snapshots__/extends-ovh.prod.yaml
+++ b/packages/kontinuous/tests/__snapshots__/extends-ovh.prod.yaml
@@ -141,7 +141,7 @@ spec:
                 - name: AWS_ENDPOINT_URL
                   value: https://s3.gra.io.cloud.ovh.net
                 - name: DESTINATION_PATH
-                  value: s3://fabrique-prod-backups/test-extends-ovh/dumps
+                  value: s3://fabrique-prod-backups/test-extends-ovh/pg-hasura/dumps
               envFrom:
                 - secretRef:
                     name: pg-hasura-app
@@ -209,7 +209,7 @@ spec:
                 - name: AWS_ENDPOINT_URL
                   value: https://s3.gra.io.cloud.ovh.net
                 - name: DESTINATION_PATH
-                  value: s3://fabrique-prod-backups/test-extends-ovh/dumps
+                  value: s3://fabrique-prod-backups/test-extends-ovh/pg-keycloak/dumps
               envFrom:
                 - secretRef:
                     name: pg-keycloak-app
@@ -734,7 +734,7 @@ spec:
   backup:
     retentionPolicy: 60d
     barmanObjectStore:
-      destinationPath: s3://fabrique-prod-backups/test-extends-ovh
+      destinationPath: s3://fabrique-prod-backups/test-extends-ovh/pg-hasura
       endpointURL: https://s3.gra.io.cloud.ovh.net
       s3Credentials:
         accessKeyId:
@@ -812,7 +812,7 @@ spec:
   backup:
     retentionPolicy: 60d
     barmanObjectStore:
-      destinationPath: s3://fabrique-prod-backups/test-extends-ovh
+      destinationPath: s3://fabrique-prod-backups/test-extends-ovh/pg-keycloak
       endpointURL: https://s3.gra.io.cloud.ovh.net
       s3Credentials:
         accessKeyId:

--- a/packages/kontinuous/tests/__snapshots__/override-env-default.dev.yaml
+++ b/packages/kontinuous/tests/__snapshots__/override-env-default.dev.yaml
@@ -142,7 +142,7 @@ spec:
                 - name: AWS_ENDPOINT_URL
                   value: https://s3.gra.io.cloud.ovh.net
                 - name: DESTINATION_PATH
-                  value: s3://fabrique-dev-backups/test-override-env-default-feature-branch-1/dumps
+                  value: s3://fabrique-dev-backups/test-override-env-default-feature-branch-1/pg/dumps
               envFrom:
                 - secretRef:
                     name: pg-app
@@ -341,7 +341,7 @@ spec:
   backup:
     retentionPolicy: 60d
     barmanObjectStore:
-      destinationPath: s3://fabrique-dev-backups/test-override-env-default-feature-branch-1
+      destinationPath: s3://fabrique-dev-backups/test-override-env-default-feature-branch-1/pg
       endpointURL: https://s3.gra.io.cloud.ovh.net
       s3Credentials:
         accessKeyId:

--- a/packages/kontinuous/tests/__snapshots__/pg.prod.yaml
+++ b/packages/kontinuous/tests/__snapshots__/pg.prod.yaml
@@ -141,7 +141,7 @@ spec:
                 - name: AWS_ENDPOINT_URL
                   value: https://s3.gra.io.cloud.ovh.net
                 - name: DESTINATION_PATH
-                  value: s3://fabrique-prod-backups/test-pg/dumps
+                  value: s3://fabrique-prod-backups/test-pg/cnpg/dumps
               envFrom:
                 - secretRef:
                     name: cnpg-app
@@ -505,7 +505,7 @@ spec:
   backup:
     retentionPolicy: 60d
     barmanObjectStore:
-      destinationPath: s3://fabrique-prod-backups/test-pg
+      destinationPath: s3://fabrique-prod-backups/test-pg/cnpg
       endpointURL: https://s3.gra.io.cloud.ovh.net
       s3Credentials:
         accessKeyId:

--- a/plugins/fabrique/charts/pg/values.yaml
+++ b/plugins/fabrique/charts/pg/values.yaml
@@ -48,7 +48,7 @@ cnpg-cluster:
     retentionPolicy: 60d
     ~tpl~sqlDumpPgSecret: "{{ index .Values.kontinuous.chartContext 2 }}-app"
     barmanObjectStore:
-      ~tpl~destinationPath: "s3://{{ .Values.global.projectName }}-{{ .Values.global.isProd | ternary `prod` `dev` }}-backups/{{ .Values.global.namespace }}{{ (ne .Values.Parent.backup.name ``) | ternary (print `-` .Values.Parent.backup.name) `` }}"
+      ~tpl~destinationPath: "s3://{{ .Values.global.projectName }}-{{ .Values.global.isProd | ternary `prod` `dev` }}-backups/{{ .Values.global.namespace }}/{{ index .Values.kontinuous.chartContext 2 }}{{ (ne .Values.Parent.backup.name ``) | ternary (print `-` .Values.Parent.backup.name) `` }}"
       ~tpl~endpointURL: "{{ .Values.global.pgBackupEndpointURL }}"
       s3Credentials:
         accessKeyId:


### PR DESCRIPTION
<img width="351" alt="Capture d’écran 2023-08-03 à 14 16 14" src="https://github.com/SocialGouv/kontinuous/assets/124937/761499a7-36d2-4496-ba37-9ba78ef38cd9">

ATM the dumps folder is in `[namespace]/dumps`. we want it to be in `[namespace]/[cluster]/dumps` in case we have multiple cluster instances.