### PR TITLE
fix(build): default imagePackage to app

### DIFF
--- a/packages/kontinuous/tests/__snapshots__/jobs-build.dev.yaml
+++ b/packages/kontinuous/tests/__snapshots__/jobs-build.dev.yaml
@@ -495,7 +495,7 @@ spec:
 
               echo \\"{\\\\\\"auths\\\\\\":{\\\\\\"$CI_REGISTRY\\\\\\":{\\\\\\"username\\\\\\":\\\\\\"$CI_REGISTRY_USER\\\\\\",\\\\\\"password\\\\\\":\\\\\\"$CI_REGISTRY_PASSWORD\\\\\\"}}}\\" > /home/user/.docker/config.json
 
-              export IMAGE_PATH=$CI_REGISTRY/test-jobs-build/app
+              export IMAGE_PATH=$CI_REGISTRY/test-jobs-build
 
               export LATEST_TAG=\\"\\"
 

--- a/packages/kontinuous/tests/__snapshots__/jobs-build.dev.yaml
+++ b/packages/kontinuous/tests/__snapshots__/jobs-build.dev.yaml
@@ -495,7 +495,7 @@ spec:
 
               echo \\"{\\\\\\"auths\\\\\\":{\\\\\\"$CI_REGISTRY\\\\\\":{\\\\\\"username\\\\\\":\\\\\\"$CI_REGISTRY_USER\\\\\\",\\\\\\"password\\\\\\":\\\\\\"$CI_REGISTRY_PASSWORD\\\\\\"}}}\\" > /home/user/.docker/config.json
 
-              export IMAGE_PATH=$CI_REGISTRY/test-jobs-build
+              export IMAGE_PATH=$CI_REGISTRY/test-jobs-build/app
 
               export LATEST_TAG=\\"\\"
 

--- a/packages/kontinuous/tests/samples/jobs-build/env/dev/values.yaml
+++ b/packages/kontinuous/tests/samples/jobs-build/env/dev/values.yaml
@@ -30,7 +30,6 @@ jobs:
       use: socialgouv/kontinuous/plugins/contrib/jobs/build
       with:
         registrySecretRefName: harbor
-        imagePackage: app
     build-hasura:
       use: socialgouv/kontinuous/plugins/contrib/jobs/build
       with:

--- a/plugins/contrib/jobs/build/use.schema.json
+++ b/plugins/contrib/jobs/build/use.schema.json
@@ -8,10 +8,14 @@
   "properties": {
     "dockerfile": {
       "description": "Path to the Dockerfile on the repository. Defaults to /Dockerfile",
+      "examples": ["./packages/api/custom.Dockerfile"],
+      "default": "./Dockerfile",
       "type": "string"
     },
     "context": {
       "description": "Docker context (cwd) when building the image. Defaults to .",
+      "examples": ["./packages/api"],
+      "default": ".",
       "type": "string"
     },
     "registrySecretRefName": {
@@ -20,14 +24,17 @@
     },
     "registry": {
       "description": "Url of your custom docker registry",
+      "examples": ["ghcr.io"],
       "type": "string"
     },
     "imagePackage": {
-      "description": "Name of the dockerfile on the registry",
+      "description": "Name of the docker image on the registry",
+      "examples": ["app"],
       "type": "string"
     },
     "imageProject": {
       "description": "Optional project name in the docker registry",
+      "examples": ["project"],
       "type": "string"
     },
     "imageRepository": {
@@ -62,14 +69,15 @@
       "type": "string"
     },
     "buildkitServiceAddr": {
-      "description": "Adress of the buildkit service. defaults to `tcp://buildkit-service.buildkit-service.svc:1234`",
+      "description": "Address of the buildkit service. defaults to `tcp://buildkit-service.buildkit-service.svc:1234`",
       "type": "string",
       "examples": ["tcp://buildkit-service.buildkit-service.svc:1234"]
-    }    
+    }
   },
   "definitions": {
     "build-args": {
-      "description": "Build args to customize the docker build",
+      "title": "Docker image build arguments",
+      "markdownDescription": "Build args to customize the docker, see [docker documentation](https://docs.docker.com/engine/reference/commandline/build/#build-arg)",
       "type": "object",
       "additionalProperties": true
     }

--- a/plugins/contrib/jobs/build/use.yaml
+++ b/plugins/contrib/jobs/build/use.yaml
@@ -10,7 +10,7 @@ runs:
     cpuRequest: 500m
     memoryLimit: 4Gi
     memoryRequest: 1Gi
-    entrypoint: ["/bin/sh","-c"]
+    entrypoint: ["/bin/sh", "-c"]
     user: 1000
     group: 1000
     annotations:
@@ -65,7 +65,7 @@ runs:
 
       mkdir -p /home/user/.docker
       echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /home/user/.docker/config.json
-      export IMAGE_PATH=$CI_REGISTRY{{ if (or $.with.imageProject $.Values.global.imageProject) }}{{ (print "/" (or $.with.imageProject $.Values.global.imageProject)) }}{{ end }}/{{ or $.with.imageRepository $.Values.global.imageRepository }}{{ if $.with.imagePackage }}{{ (print "/" $.with.imagePackage) }}{{ end }}{{ if $.with.target }}{{ (print "-" $.with.target) }}{{ end }}
+      export IMAGE_PATH=$CI_REGISTRY{{ if (or $.with.imageProject $.Values.global.imageProject) }}{{ (print "/" (or $.with.imageProject $.Values.global.imageProject)) }}{{ end }}/{{ or $.with.imageRepository $.Values.global.imageRepository }}{{ if $.with.imagePackage }}{{ (print "/" $.with.imagePackage) }}{{else}}/app{{ end }}{{ if $.with.target }}{{ (print "-" $.with.target) }}{{ end }}
       export LATEST_TAG=""
       if [ "{{ $.Values.global.isProd }}" = "true" ]; then
         export LATEST_TAG=",$IMAGE_PATH:latest"
@@ -92,5 +92,5 @@ runs:
         {{ if $.with.target -}}
         --target="{{ $.with.target }}" \
         {{ end -}}
-      
+
       echo "$IMAGE_PATH:{{ or $.with.imageTag $.Values.global.imageTag }}" >$KONTINUOUS_OUTPUT/IMAGE


### PR DESCRIPTION
RFC

At the moment :
 - In the `app` chart, when no `imagePackage` is specified, it uses `app` docker image
 - In the `build` job, when no `imagePackage` is specified, it uses `project` docker image

This PR makes `build` and `job` follow the same behaviour with the `imagePackage` parameter : when no `imagePackage` is specified, it will use `app` by default

This should be retro-compatible