### PR TITLE
fix(buildkit): fallback to local build when no cert defined

### DIFF
--- a/plugins/contrib/jobs/build/use.yaml
+++ b/plugins/contrib/jobs/build/use.yaml
@@ -44,23 +44,24 @@ runs:
       buildctl_options_cache=""
       buildctl_options_mtls=""
 
+
+      buildctl_cmd=buildctl-daemonless.sh
+      buildctl_options_cache="\
+        --export-cache type=inline \
+        --import-cache type=registry,ref=$IMAGE_PATH:{{ $.Values.global.branchSlug32 }} \
+        "
+
       {{ if (or $.with.buildkitServiceEnabled $.Values.global.buildkitServiceEnabled) }}
-      buildctl_cmd="buildctl \
-        --addr {{ or $.with.buildkitServiceAddr "tcp://buildkit-service.buildkit-service.svc:1234" }} \
-      "
       if [ -f /buildkit-certs/cert.pem ]; then
+        buildctl_cmd="buildctl \
+          --addr {{ or $.with.buildkitServiceAddr "tcp://buildkit-service.buildkit-service.svc:1234" }} \
+        "
         buildctl_options_mtls="\
           --tlscacert /buildkit-certs/ca.pem \
           --tlscert /buildkit-certs/cert.pem \
           --tlskey /buildkit-certs/key.pem \
         "
       fi
-      {{ else }}
-      buildctl_cmd=buildctl-daemonless.sh
-      buildctl_options_cache="\
-        --export-cache type=inline \
-        --import-cache type=registry,ref=$IMAGE_PATH:{{ $.Values.global.branchSlug32 }} \
-        "
       {{ end }}
 
       mkdir -p /home/user/.docker


### PR DESCRIPTION
C'est un fallback pour builder localement si jamais le buildkit service n'est pas accessible (via la présence du secret)