### PR TITLE
fix(pg): use 512M as default memory request

### DIFF
--- a/packages/kontinuous/tests/__snapshots__/extends-ovh.dev.yaml
+++ b/packages/kontinuous/tests/__snapshots__/extends-ovh.dev.yaml
@@ -595,7 +595,7 @@ spec:
     limits:
       memory: 1G
     requests:
-      memory: 128M
+      memory: 512M
   storage:
     size: 8Gi
     storageClass: csi-cinder-high-speed
@@ -670,7 +670,7 @@ spec:
     limits:
       memory: 1G
     requests:
-      memory: 128M
+      memory: 512M
   storage:
     size: 8Gi
     storageClass: csi-cinder-high-speed

--- a/packages/kontinuous/tests/__snapshots__/extends-ovh.prod.yaml
+++ b/packages/kontinuous/tests/__snapshots__/extends-ovh.prod.yaml
@@ -358,7 +358,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 41m
-              memory: 121Mi
+              memory: 512Mi
           securityContext:
             runAsUser: 1001
             runAsGroup: 1001
@@ -758,7 +758,7 @@ spec:
     limits:
       memory: 1G
     requests:
-      memory: 128M
+      memory: 512M
   storage:
     size: 8Gi
     storageClass: managed-csi
@@ -852,7 +852,7 @@ spec:
     limits:
       memory: 1G
     requests:
-      memory: 128M
+      memory: 512M
   storage:
     size: 8Gi
     storageClass: managed-csi

--- a/packages/kontinuous/tests/__snapshots__/extends-ovh.prod.yaml
+++ b/packages/kontinuous/tests/__snapshots__/extends-ovh.prod.yaml
@@ -358,7 +358,7 @@ spec:
               memory: 1Gi
             requests:
               cpu: 41m
-              memory: 512Mi
+              memory: 121Mi
           securityContext:
             runAsUser: 1001
             runAsGroup: 1001

--- a/packages/kontinuous/tests/__snapshots__/override-env-default.dev.yaml
+++ b/packages/kontinuous/tests/__snapshots__/override-env-default.dev.yaml
@@ -352,7 +352,7 @@ spec:
     limits:
       memory: 1G
     requests:
-      memory: 128M
+      memory: 512M
   storage:
     size: 8Gi
     storageClass: csi-cinder-high-speed

--- a/plugins/fabrique/charts/pg/values.yaml
+++ b/plugins/fabrique/charts/pg/values.yaml
@@ -47,7 +47,7 @@ cnpg-cluster:
 
   resources:
     requests:
-      ~tpl~memory: "{{ or (and .Values.Parent._ProjectValues (index .Values.Parent._ProjectValues `cnpg-cluster`).resources (index .Values.Parent._ProjectValues `cnpg-cluster`).resources.requests (index .Values.Parent._ProjectValues `cnpg-cluster`).resources.requests.memory) `128M` }}"
+      ~tpl~memory: "{{ or (and .Values.Parent._ProjectValues (index .Values.Parent._ProjectValues `cnpg-cluster`).resources (index .Values.Parent._ProjectValues `cnpg-cluster`).resources.requests (index .Values.Parent._ProjectValues `cnpg-cluster`).resources.requests.memory) `512M` }}"
     limits:
       ~tpl~memory: "{{ or (and .Values.Parent._ProjectValues (index .Values.Parent._ProjectValues `cnpg-cluster`).resources (index .Values.Parent._ProjectValues `cnpg-cluster`).resources.limits (index .Values.Parent._ProjectValues `cnpg-cluster`).resources.limits.memory) `1G` }}"
 


### PR DESCRIPTION
Set 512Mb as default memory request for CNPG pods